### PR TITLE
Fix: `fit_selection` attribute in GMXTrjConvStrEns should be `selection`

### DIFF
--- a/biobb_analysis/gromacs/gmx_trjconv_str_ens.py
+++ b/biobb_analysis/gromacs/gmx_trjconv_str_ens.py
@@ -79,7 +79,7 @@ class GMXTrjConvStrEns(BiobbObject):
         }
 
         # Properties specific for BB
-        self.fit_selection = properties.get('fit_selection', "System")
+        self.selection = properties.get('selection', "System")
         self.skip = properties.get('skip', 1)
         self.start = properties.get('start', 0)
         self.end = properties.get('end', 0)


### PR DESCRIPTION
Hi!
I thought this was a quick fix so I went ahead and opened the PR, hope it's ok.

Prevents `BiobbObject` from taking it as an error and giving this warning:
```
UserWarning: Warning: selection is not a recognized property. The most similar property is: fit_selection
```