### PR TITLE
Fix stage_io_dict bug due to new stage_files()

### DIFF
--- a/biobb_analysis/gromacs/gmx_trjconv_str.py
+++ b/biobb_analysis/gromacs/gmx_trjconv_str.py
@@ -131,7 +131,7 @@ class GMXTrjConvStr(BiobbObject):
             self.cmd.append('-fit')
             self.cmd.append(self.fit)
 
-        if self.stage_io_dict["in"]["input_index_path"]:
+        if self.stage_io_dict["in"].get("input_index_path"):
             self.cmd.extend(['-n', self.stage_io_dict["in"]["input_index_path"]])
 
         # Add stdin input file


### PR DESCRIPTION
Was getting a `KeyError` from this line. 

`stage_io_dict` used to be initialized from `io_dict`, so `stage_io_dict["in"]["input_index_path"]` was always initialized (to `None`, in case the user didn't supply a ndx file.

There's probably other lines like this one.