### PR TITLE
Fix/gmx image

### DIFF
--- a/biobb_analysis/gromacs/gmx_image.py
+++ b/biobb_analysis/gromacs/gmx_image.py
@@ -189,7 +189,7 @@ class GMXImage(BiobbObject):
 
 
 def gmx_image(input_traj_path: str, input_top_path: str, output_traj_path: str, input_index_path: Optional[str] = None, properties: Optional[dict] = None, **kwargs) -> int:
-    """Execute the :class:`GMXImage <gromacs.gmx_image.GMXImage>` class and
+    """Create the :class:`GMXImage <gromacs.gmx_image.GMXImage>` class and
     execute the :meth:`launch() <gromacs.gmx_image.GMXImage.launch>` method."""
     return GMXImage(**dict(locals())).launch()
 

--- a/biobb_analysis/gromacs/gmx_image.py
+++ b/biobb_analysis/gromacs/gmx_image.py
@@ -129,6 +129,9 @@ class GMXImage(BiobbObject):
     def launch(self) -> int:
         """Execute the :class:`GMXImage <gromacs.gmx_image.GMXImage>` object."""
 
+        # check input/output paths and parameters
+        self.check_data_params(self.out_log, self.err_log)
+
         # If fitting provided, echo fit_selection
         if self.fit == 'none':
             if self.center:
@@ -142,9 +145,6 @@ class GMXImage(BiobbObject):
                 selections = self.fit_selection + ' ' + self.center_selection + ' ' + self.output_selection
             else:
                 selections = self.fit_selection + ' ' + self.output_selection
-
-        # check input/output paths and parameters
-        self.check_data_params(self.out_log, self.err_log)
 
         # Setup Biobb
         if self.check_restart():

--- a/biobb_analysis/gromacs/gmx_image.py
+++ b/biobb_analysis/gromacs/gmx_image.py
@@ -89,7 +89,7 @@ class GMXImage(BiobbObject):
         self.cluster_selection = properties.get('cluster_selection', "System")
         self.output_selection = properties.get('output_selection', "System")
         self.pbc = properties.get('pbc', "mol")
-        self.center = properties.get('dista', True)
+        self.center = properties.get('center', True)
         self.ur = properties.get('ur', "compact")
         self.fit = properties.get('fit', "none")
         self.properties = properties


### PR DESCRIPTION
# Fix `gmx_image`: `center: false` is ignored and the wrong index group is selected

## Summary

In `biobb_analysis/gromacs/gmx_image.py`, the `center` property is never read
correctly, and the list of groups sent to `gmx trjconv` on stdin is built before
the properties are validated. When a user sets `center: false`, `gmx_image` sends
the wrong number of groups to `trjconv`, so `trjconv` picks the wrong group to
write out. On a trajectory that has fewer atoms than the reference topology, this
crashes with a fatal error.

## What goes wrong

There are two problems, and together they cause the bug.

**1. A typo makes `center` always `True` at first.**

In `GMXImage.__init__`:

```python
self.center = properties.get('dista', True)
```

There is no `dista` property, so this always falls back to `True` and ignores the
user's `center` setting. (The correct key is `center`, which is what `get_center`
in `common.py` reads.)

**2. The stdin group list is built before the properties are resolved.**

In `launch()`, the string of groups to feed `trjconv` is assembled first, using the
wrong `center` value from step 1:

```python
# built here, using self.center == True (from the typo above)
if self.fit == 'none':
    if self.center:
        selections = self.center_selection + ' ' + self.output_selection
    else:
        selections = self.output_selection
    ...

# only now are the real values resolved
self.check_data_params(self.out_log, self.err_log)   # sets self.center correctly
```

`check_data_params()` later fixes `self.center` to the real value (e.g. `False`),
and the command line correctly gets `-nocenter`:

```python
self.cmd.append('-center' if self.center else '-nocenter')
```

So the command line and the stdin disagree:

- **stdin** was built as if centering were on → it lists **two** groups
  (a center group + the output group).
- **command line** correctly says `-nocenter` → `trjconv` expects **one** group.

`trjconv` therefore reads the *first* group name as the output group. That first
name is the center group (which defaults to `"System"` when the user didn't set
one), not the intended output group.

PR explanation made with Claude - it's ok I checked - but changes in the code done myself :) 